### PR TITLE
Checkboxを実装 & Vitestでreactのrenderがうまくいかなかったので修正

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -35,5 +35,4 @@ pre-push:
       glob: '*.{ts,tsx}'
       run: npm run lint {push_files}
     test:
-      glob: '*.{ts,tsx}'
-      run: npm test -- --run {push_files}
+      run: npm test -- --run

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
         "vite": "^5.4.1",
+        "vite-tsconfig-paths": "^5.0.1",
         "vitest": "^2.0.5"
       }
     },
@@ -9882,6 +9883,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -13807,6 +13815,27 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.3.tgz",
+      "integrity": "sha512-ulNZP1SVpRDesxeMLON/LtWM8HIgAJEIVpVVhBM6gsmvQ8+Rh+ZG7FWGvHh7Ah3pRABwVJWklWCr/BTZSv0xnQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -14325,6 +14354,26 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.0.1.tgz",
+      "integrity": "sha512-yqwv+LstU7NwPeNqajZzLEBVpUFU6Dugtb2P84FXuvaoYA+/70l9MHE+GYfYAycVyPSDYZ7mjOFuYBRqlEpTig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
+    "vite-tsconfig-paths": "^5.0.1",
     "vitest": "^2.0.5"
   },
   "msw": {

--- a/src/components/parts/Checkbox/Checkbox.stories.tsx
+++ b/src/components/parts/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { Checkbox } from './Checkbox';
@@ -12,8 +12,32 @@ const meta = {
   tags: ['autodocs'],
 } satisfies Meta<typeof Checkbox>;
 export default meta;
+type Story = StoryObj<typeof meta>;
 
-export const Default = () => {
+export const Default: Story = {
+  argTypes: {
+    checked: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    onCheckedChange: {
+      action: 'onCheckedChange',
+    },
+    label: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+  args: {
+    label: 'label',
+    checked: false,
+    onCheckedChange: () => undefined,
+  },
+};
+
+export const Controlled = () => {
   const [checked, setChecked] = useState<boolean>(false);
 
   return (

--- a/src/components/parts/Checkbox/Checkbox.stories.tsx
+++ b/src/components/parts/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta } from '@storybook/react';
+import { useState } from 'react';
+
+import { Checkbox } from './Checkbox';
+
+const meta = {
+  title: 'CheckBox',
+  component: Checkbox,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Checkbox>;
+export default meta;
+
+export const Default = () => {
+  const [checked, setChecked] = useState<boolean>(false);
+
+  return (
+    <>
+      <Checkbox
+        id={'sample'}
+        label={'label'}
+        checked={checked}
+        onCheckedChange={() => setChecked((prev) => !prev)}
+      />
+    </>
+  );
+};

--- a/src/components/parts/Checkbox/Checkbox.test.tsx
+++ b/src/components/parts/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, vi } from 'vitest';
+
+import { Checkbox } from './Checkbox';
+
+describe('Checkbox Component', () => {
+  const handleChange = vi.fn();
+
+  afterEach(() => {
+    vitest.resetAllMocks();
+  });
+
+  test('renders correctly with the provided label', () => {
+    render(<Checkbox label='Test Label' onCheckedChange={handleChange} />);
+
+    const label = screen.getByText('Test Label');
+    expect(label).toBeVisible();
+  });
+
+  test('toggles the checkbox when clicked', () => {
+    // 状態を管理するラッパーコンポーネント
+    const CheckboxWithState = () => {
+      const [isChecked, setIsChecked] = useState(false);
+
+      return (
+        <Checkbox
+          label='Test Label'
+          checked={isChecked}
+          onCheckedChange={() => {
+            setIsChecked(!isChecked);
+            handleChange();
+          }}
+        />
+      );
+    };
+
+    render(<CheckboxWithState />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+
+    // Click to toggle the checkbox
+    fireEvent.click(checkbox);
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(checkbox).toBeChecked();
+  });
+
+  test('is checked when the checked prop is true', () => {
+    render(<Checkbox label='Test Label' checked={true} onCheckedChange={handleChange} />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeChecked();
+  });
+
+  test('is disabled when the disabled prop is true', () => {
+    render(<Checkbox label='Test Label' disabled={true} onCheckedChange={handleChange} />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeDisabled();
+  });
+});

--- a/src/components/parts/Checkbox/Checkbox.tsx
+++ b/src/components/parts/Checkbox/Checkbox.tsx
@@ -1,0 +1,64 @@
+import { css } from '@emotion/react';
+import { forwardRef } from 'react';
+
+const checkboxStyle = {
+  wrapper: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    cursor: 'pointer',
+    userSelect: 'none',
+    '&:hover': {
+      opacity: 0.8,
+    },
+    '&:active': {
+      opacity: 0.6,
+    },
+  }),
+
+  checkbox: css({
+    width: '16px',
+    height: '16px',
+    flexShrink: 0,
+    margin: 0,
+    cursor: 'pointer',
+  }),
+
+  label: css({
+    cursor: 'pointer',
+  }),
+};
+
+type CheckboxElement = React.ElementRef<'input'>;
+type PrimitiveButtonProps = React.ComponentPropsWithoutRef<'input'>;
+interface CheckboxProps extends PrimitiveButtonProps {
+  label: React.ReactNode;
+  required?: boolean;
+  onCheckedChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+const Checkbox = forwardRef<CheckboxElement, CheckboxProps>(
+  ({ checked, id, required, onCheckedChange = () => undefined, label, ...props }, ref) => {
+    return (
+      <div css={[checkboxStyle.wrapper]}>
+        <input
+          {...props}
+          css={[checkboxStyle.checkbox]}
+          checked={checked}
+          type='checkbox'
+          role='checkbox'
+          aria-checked={checked}
+          aria-required={required}
+          ref={ref}
+          id={id}
+          onChange={onCheckedChange}
+        />
+        <label css={[checkboxStyle.label]} htmlFor={id}>
+          {label}
+        </label>
+      </div>
+    );
+  },
+);
+Checkbox.displayName = 'Checkbox';
+
+export { Checkbox };

--- a/src/components/parts/Checkbox/index.ts
+++ b/src/components/parts/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export { Checkbox } from './Checkbox';

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,5 +24,5 @@
     // globalでvitestを使うための設定
     "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["src", "vitest.setup.ts", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,11 @@
+import react from '@vitejs/plugin-react-swc';
+import tsconfigPaths from 'vite-tsconfig-paths';
 import { configDefaults, defineConfig } from 'vitest/config';
 
 const exclude = [...configDefaults.exclude, 'api/*', 'public/*', '.storybook/*'];
 
 export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
   test: {
     globals: true,
     environment: 'happy-dom',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,11 @@ export default defineConfig({
     environment: 'happy-dom',
     exclude,
     coverage: {
-      exclude,
+      exclude: [
+        ...exclude,
+        './src/components/parts/**/*.stories.tsx',
+        './src/components/**/index.ts',
+      ],
     },
     setupFiles: ['./vitest.setup.ts'],
   },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,3 +1,5 @@
+import '@testing-library/jest-dom/vitest';
+
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 


### PR DESCRIPTION
Checkboxを実装。

それに伴い、以下の設定がvitestから不足していたので修正。
- vite-tsconfig-paths をvitest.config.tsで読み込むように
- @vitejs/plugin-react-swc をvitest.config.tsで読み込むように
- tsconfig.jsonのpathに、vitest.config.tsとvitest.setup.tsが不足していたので追加
- '@testing-library/jest-dom/vitest' を、vitest.setup.tsでimport