### PR TITLE
複数リクエストを同時に行うSWRのラッパーを実装

### DIFF
--- a/src/hooks/useMultipleSWR.test.tsx
+++ b/src/hooks/useMultipleSWR.test.tsx
@@ -1,0 +1,40 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { mockPopulationCompositionPerYear } from '../mocks/handlers/api/resas/population/composition/perYear';
+import { useMultipleSWR } from './useMultipleSWR';
+
+describe('useMultipleSWRの動作確認', () => {
+  const url = [
+    '/api/resas/population/composition/perYear?cityCode=-&prefCode=1',
+    '/api/resas/population/composition/perYear?cityCode=-&prefCode=2',
+    '/api/resas/population/composition/perYear?cityCode=-&prefCode=3',
+    '/api/resas/population/composition/perYear?cityCode=-&prefCode=4',
+  ];
+
+  test('should return data from the API', async () => {
+    const { result } = renderHook(() => useMultipleSWR(url));
+    await waitFor(() => {
+      expect(result.current.data).toEqual([
+        { message: null, result: mockPopulationCompositionPerYear[1] },
+        { message: null, result: mockPopulationCompositionPerYear[2] },
+        { message: null, result: mockPopulationCompositionPerYear[3] },
+        { message: null, result: mockPopulationCompositionPerYear[4] },
+      ]);
+    });
+  });
+
+  test('should handle error', async () => {
+    const { result } = renderHook(() =>
+      useMultipleSWR(['/api/test?error=1', '/api/test?error=1', ...url]),
+    );
+    await waitFor(async () => {
+      expect(result.current.error).toBeDefined();
+      expect(result.current.error.message).toEqual(
+        [
+          'Error fetching http://localhost:3000/api/test?error=1: { status: 500, message: Internal Server Error}',
+          'Error fetching http://localhost:3000/api/test?error=1: { status: 500, message: Internal Server Error}',
+        ].join('\n'),
+      );
+    });
+  });
+});

--- a/src/hooks/useMultipleSWR.tsx
+++ b/src/hooks/useMultipleSWR.tsx
@@ -1,0 +1,42 @@
+import useSWR from 'swr';
+
+const multipleFetcher = async (urls: string[]) => {
+  const responses = await Promise.all(urls.map((url) => fetch(url)));
+
+  const filteredErrors = (res: Response, index: number) => {
+    if (!res.ok) {
+      return { url: urls[index], status: res.status, statusText: res.statusText };
+    }
+    return false;
+  };
+
+  const errors = responses.filter(filteredErrors);
+
+  if (errors.length > 0) {
+    const errorMessages = errors
+      .map(
+        (err) => `Error fetching ${err.url}: { status: ${err.status}, message: ${err.statusText}}`,
+      )
+      .join('\n');
+    throw new Error(errorMessages);
+  }
+
+  return Promise.all(responses.map((res) => res.json()));
+};
+
+/**
+ * SWRを利用して複数のURLからデータを取得する
+ *
+ * エラーが発生した場合は、以下の形式でエラーメッセージを返す。
+ * ```
+ * Error fetching ${url}: { status: ${status}, message: ${statusText}}
+ * ```
+ *
+ * エラーが複数発生した場合は、エラーメッセージを改行で連結する。
+ *
+ * @param urls URLの配列
+ * @returns SWRのデータ
+ */
+export function useMultipleSWR([...urls]: string[]) {
+  return useSWR(urls, multipleFetcher);
+}


### PR DESCRIPTION
複数のリクエストを送るのが不便なので、promise.allを用いたラッパーを実装