### PR TITLE
都道府県一覧のデザインを修正

### DIFF
--- a/src/features/Prefectures/PrefecturesList/presenter.tsx
+++ b/src/features/Prefectures/PrefecturesList/presenter.tsx
@@ -20,7 +20,7 @@ export function PrefectureListPresenter({
         {prefectures
           ? prefectures.map((prefecture) => (
               <ol
-                className='flex justify-center cursor-pointer select-none hover:opacity-80 active:opacity-60'
+                className='flex justify-center cursor-pointer select-none hover:opacity-80 active:opacity-60 sm:justify-start'
                 key={prefecture.prefCode}
               >
                 <Checkbox


### PR DESCRIPTION
狭い画面だと中央に合わせた方が綺麗なので、レスポンシブに変更